### PR TITLE
Added ignore flag

### DIFF
--- a/bin/flow-copy-source.js
+++ b/bin/flow-copy-source.js
@@ -4,10 +4,12 @@
 var flowCopy = require('..');
 
 var argv = require('yargs')
-  .usage('Usage: $0 [-v|--verbose] SRC... DEST')
+  .usage('Usage: $0 [-v|--verbose] [-i PATTERN]... SRC... DEST')
   .boolean('verbose')
   .alias('v', 'verbose')
   .describe('v', 'Show changes')
+  .alias('i', 'ignore')
+  .describe('i', 'ignore pattern (glob expression)')
   .demand(2)
   .strict()
   .argv;
@@ -15,7 +17,7 @@ var argv = require('yargs')
 var srcs = argv._.slice(0, -1);
 var dest = argv._[argv._.length-1];
 
-flowCopy(srcs, dest, {verbose: argv.verbose})
+flowCopy(srcs, dest, {verbose: argv.verbose, ignore: argv.ignore})
   .catch(err => {
     console.error(err);
     process.exit(1);

--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,11 @@ the transpiled code, so that Flow can use the type definitions in the original
 source code.
 
 ```
-Usage: flow-copy-source [-v|--verbose] SRC... DEST
+Usage: flow-copy-source [-v|--verbose] [-i PATTERN]... SRC... DEST
 
 Options:
   -v, --verbose  Show changes                                          [boolean]
+  -i, --ignore   ignore pattern (glob expression)
 ```
 
 This module also exports the `flowCopySource(sources, dest, options)` function.

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,10 @@ var kefirCopyFile = require('./kefir-copy-file');
 
 module.exports = function flowCopySource(sources, dest, options) {
   var verbose = options && options.verbose;
+  var ignore = options && options.ignore;
   return Kefir.merge(
       sources.map(src =>
-        kefirGlob('**/*.js?(x)', {cwd: src, strict: true})
+        kefirGlob('**/*.js?(x)', {cwd: src, strict: true, ignore: ignore})
           .map(match => ({src, match}))
       )
     )


### PR DESCRIPTION
With a source folder like this:
```
src/
├── utils.js
└── utils.test.js
```

I can ignore *test.js files with babel with `--ignore=test.js`, since
test files are not published the .flow files for them is not needed and
bloats the published package.

With this flag i can ignore test files with the `--ignore` flag.
```
flow-copy-source -i "*.test.js" src lib
```

Multiple ignores are supported:
```
flow-copy-source -i "*.test.js" -i "*.spec.js" src lib
```