### PR TITLE
add file pattern glob matching

### DIFF
--- a/bin/flow-copy-source.js
+++ b/bin/flow-copy-source.js
@@ -4,9 +4,12 @@
 var flowCopy = require('..');
 
 var argv = require('yargs')
-  .usage('Usage: $0 [-v|--verbose] [-w|--watch] [-i PATTERN]... SRC... DEST')
+  .usage('Usage: $0 [-v|--verbose] [-w|--watch] [-f|--file-pattern PATTERN] [-i PATTERN]... SRC... DEST')
   .boolean('verbose')
   .boolean('watch')
+  .alias('f', 'file-pattern')
+  .describe('f', 'file pattern (glob expression)')
+  .default('f', '**/*.js?(x)')
   .alias('v', 'verbose')
   .describe('v', 'Show changes')
   .alias('w', 'watch')
@@ -20,8 +23,12 @@ var argv = require('yargs')
 var srcs = argv._.slice(0, -1);
 var dest = argv._[argv._.length-1];
 
-flowCopy(srcs, dest, {verbose: argv.verbose, ignore: argv.ignore, watch: argv.watch})
-  .catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+flowCopy(srcs, dest, {
+  filePattern: argv.filePattern,
+  verbose: argv.verbose,
+  ignore: argv.ignore,
+  watch: argv.watch,
+}).catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,10 @@ source code.
 Usage: bin/flow-copy-source.js [-v|--verbose] [-w|--watch] [-i PATTERN]... SRC... DEST
 
 Options:
-  -v, --verbose  Show changes                                          [boolean]
-  -w, --watch    Re-copy files on change                               [boolean]
-  -i, --ignore   ignore pattern (glob expression)
+  -v, --verbose       Show changes                                          [boolean]
+  -w, --watch         Re-copy files on change                               [boolean]
+  -i, --ignore        ignore pattern (glob expression)
+  -f, --file-pattern  file pattern (glob expression, default)
 ```
 
 This module also exports the `flowCopySource(sources, dest, options)` function.

--- a/src/index.js
+++ b/src/index.js
@@ -5,25 +5,24 @@ var Kefir = require('kefir');
 var kefirGlob = require('./kefir-glob');
 var kefirCopyFile = require('./kefir-copy-file');
 
-var jsAndJsxPattern = '**/*.js?(x)';
-
 module.exports = function flowCopySource(sources, dest, options) {
   var verbose = options && options.verbose;
   var ignore = options && options.ignore;
   var watch = options && options.watch;
+  var filePattern = options && options.filePattern;
 
   return Kefir.merge(
       sources.map(src => {
         var filesToCopy;
         if (watch) {
           var chokidar = require('chokidar');
-          var watcher = chokidar.watch(jsAndJsxPattern, {cwd: src, ignored: ignore});
+          var watcher = chokidar.watch(filePattern, {cwd: src, ignored: ignore});
           filesToCopy = Kefir.merge([
             Kefir.fromEvents(watcher, 'add'),
             Kefir.fromEvents(watcher, 'change')
           ]);
         } else {
-          filesToCopy = kefirGlob(jsAndJsxPattern, {cwd: src, strict: true, ignore});
+          filesToCopy = kefirGlob(filePattern, {cwd: src, strict: true, ignore});
         }
 
         return filesToCopy.map(match => ({src, match}));


### PR DESCRIPTION
I have some projects that import file types other than js/jsx.

An option like this would be extremely useful to have the flexibility to output additional file types with .flow extensions.