### PR TITLE
[Enhancement] support standard .mjs extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var Kefir = require('kefir');
 var kefirGlob = require('./kefir-glob');
 var kefirCopyFile = require('./kefir-copy-file');
 
-var jsAndJsxPattern = '**/*.?(m)js?(x)';
+var jsAndJsxPattern = '**/*.{js, mjs, jsx}';
 
 module.exports = function flowCopySource(sources, dest, options) {
   var verbose = options && options.verbose;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var Kefir = require('kefir');
 var kefirGlob = require('./kefir-glob');
 var kefirCopyFile = require('./kefir-copy-file');
 
-var jsAndJsxPattern = '**/*.js?(x)';
+var jsAndJsxPattern = '**/*.?(m)js?(x)';
 
 module.exports = function flowCopySource(sources, dest, options) {
   var verbose = options && options.verbose;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var Kefir = require('kefir');
 var kefirGlob = require('./kefir-glob');
 var kefirCopyFile = require('./kefir-copy-file');
 
-var jsAndJsxPattern = '**/*.{js, mjs, jsx}';
+var jsAndJsxPattern = '**/*.{js,mjs,jsx}';
 
 module.exports = function flowCopySource(sources, dest, options) {
   var verbose = options && options.verbose;


### PR DESCRIPTION
This PR adds support for `.mjs` extensions. 

With Node.js now supporting `.mjs` extensions for ES modules, it makes sense to support this extension.