### PR TITLE
Upgrade chokidar to support Node 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/AgentME/flow-copy-source#readme",
   "dependencies": {
-    "chokidar": "^2.0.0",
+    "chokidar": "^2.0.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.0.0",
     "kefir": "^3.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,7 +477,7 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chokidar@^2.0.0:
+chokidar@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
   dependencies:


### PR DESCRIPTION
`chokidar` v2.0.0 uses `upath` c1.0.2 which had a `<=9` restriction for its `package.json` `engines` property. 

`chokidar` v2.0.3 is the latest and uses `upath` v1.0.5 which no longer has this restriction.

Currently we are forced to use `--ignore-engines` when building our libraries that use this project.